### PR TITLE
🎫 Add Ticket Purchase System (Free & Paid)

### DIFF
--- a/server/controllers/ticket.controller.js
+++ b/server/controllers/ticket.controller.js
@@ -1,0 +1,30 @@
+const Ticket = require('../models/Ticket');
+const Raffle = require('../models/Raffle');
+
+exports.purchaseTicket = async (req, res) => {
+  try {
+    const { raffleId, isFree } = req.body;
+    const userId = req.user.id;
+
+    const raffle = await Raffle.findById(raffleId);
+    if (!raffle || !raffle.isActive) {
+      return res.status(404).json({ error: 'Raffle not found or inactive' });
+    }
+
+    if (isFree) {
+      const existing = await Ticket.findOne({ raffle: raffleId, user: userId, isFree: true });
+      if (existing) return res.status(400).json({ error: 'Free ticket already claimed' });
+    }
+
+    const ticket = new Ticket({ raffle: raffleId, user: userId, isFree });
+    await ticket.save();
+
+    raffle.ticketsSold += 1;
+    await raffle.save();
+
+    res.status(201).json(ticket);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,13 @@ console.log("🛣️ Product routes loaded at /api/products");
 // Raffle Connection
 const raffleRoutes = require('./routes/raffle.routes');
 app.use('/api/raffles', raffleRoutes);
+console.log("🛣️ Raffle routes loaded at /api/raffles");
+
+// Ticket Connection
+const ticketRoutes = require('./routes/ticket.routes');
+app.use('/api/tickets', ticketRoutes);
+console.log("🛣️ Ticket routes loaded at /api/tickets");
+
 
 // Connect to MongoDB
 mongoose.connect(process.env.MONGO_URI, {

--- a/server/models/Ticket.js
+++ b/server/models/Ticket.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const ticketSchema = new mongoose.Schema({
+  raffle: { type: mongoose.Schema.Types.ObjectId, ref: 'Raffle', required: true },
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  isFree: { type: Boolean, default: false }
+});
+
+module.exports = mongoose.model('Ticket', ticketSchema);
+// This model represents a ticket in a raffle system, linking to the raffle and user who owns it.
+// It includes fields for creation date and whether the ticket is free or not.

--- a/server/routes/ticket.routes.js
+++ b/server/routes/ticket.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ticketController = require('../controllers/ticket.controller');
+const {authMiddleware} = require('../middleware/auth.middleware');
+
+router.post('/', authMiddleware, ticketController.purchaseTicket);
+
+module.exports = router;


### PR DESCRIPTION
This PR adds the ticket-purchasing mechanism for raffle participation.

✅ Features Implemented:
Ticket model with raffle, user, isFree, and createdAt

Protected route: POST /api/tickets

Allows users to join raffles using:

A free ticket (only one per raffle per user)

A paid ticket (supports future payment integration)

Raffle ticket counter (ticketsSold) is updated on every purchase

Ownership and duplicate free-ticket protections implemented

Fully tested using Thunder Client

📌 Future Plans:
Validate payment for paid tickets

Limit free tickets per user per day

Dashboard for tracking user’s ticket history

